### PR TITLE
test: add case to verify no CSS var media queries in extracted styles

### DIFF
--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -84,4 +84,13 @@ describe('Static-Style-Extract', () => {
     const cssText = extractStyle();
     expect(cssText).toContain('.ant-modal-confirm-title');
   });
+
+  it('should not contain media queries with CSS var in min-width or max-width', () => {
+    const cssText = extractStyle();
+    // Check for media queries using CSS var like: @media (min-width: var(--xxx))
+    const cssVarMediaRegex =
+      /@media\s*\([^)]*(?:min-width|max-width)\s*:\s*var\(/;
+    const match = cssVarMediaRegex.test(cssText);
+    expect(match).toBe(false);
+  });
 });


### PR DESCRIPTION
Check that extracted CSS does not contain media queries with min-width or max-width using CSS custom properties (e.g. @media (min-width: var(--xxx))).

context
https://github.com/ant-design/ant-design/pull/57372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 测试

* **Tests**
  * 增强了测试覆盖范围，新增测试用例以验证生成的 CSS 输出不包含在媒体查询中使用 CSS 变量作为断点值的情况，确保样式生成的正确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->